### PR TITLE
use standard Rust comment formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target/*
-endio_derive/target/*
+/target
+/endio_derive/target

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -1,23 +1,18 @@
-/**
-    Only necessary for custom (de-)serializations.
-
-    You can use this as a blanket impl trait bound to write code that is not endian-specific.
-
-    You can't implement this trait, it only exists as a trait bound.
-*/
+/// Only necessary for custom (de-)serializations.
+///
+/// You can use this as a blanket impl trait bound to write code that is not endian-specific.
+///
+/// You can't implement this trait, it only exists as a trait bound.
 pub trait Endianness: private::Sealed {}
 
-/**
-    Only necessary for custom (de-)serializations.
-
-    You can use this as a type parameter in your implementation to write code specific to big endian.
-*/
+/// Only necessary for custom (de-)serializations.
+///
+/// You can use this as a type parameter in your implementation to write code specific to big endian.
 pub struct BigEndian;
-/**
-    Only necessary for custom (de-)serializations.
 
-    You can use this as a type parameter in your implementation to write code specific to little endian.
-*/
+/// Only necessary for custom (de-)serializations.
+///
+/// You can use this as a type parameter in your implementation to write code specific to little endian.
 pub struct LittleEndian;
 
 impl Endianness for BigEndian {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,126 +1,124 @@
-/*!
-    ## Simple and ergonomic reading and writing of binary data.
-
-    `std::io::{Read, Write}` only allow reading and writing of raw bytes. This can be cumbersome when trying to read/write data, e.g. integers, as they have to be converted from/to bytes first.
-    This crate allows direct reading/writing of data types, making this as easy as
-
-    `let value: u8 = reader.read()?;`
-
-    and
-
-    `writer.write(42u8);`.
-
-    ### Per-object endianness specification
-
-    When working with integers consisting of multiple bytes, two kinds of byte ordering are possible, big and little endian. This crate can automatically convert integers from/to the desired endianness when they're read/written, without you having to specify the endianness for every read/write call. This works by making the endianness part of the type of the read/write implementor through different traits. In most scenarios the endianness stays the same for the entirety of the I/O, so this can save a lot of typing.
-
-    You aren't bound to the specified endianness for the entirety of the I/O. If you need to work with data where the endianness changes midway through, you can explicitly override the endianness with the `_be`-/`_le` -suffixed methods.
-
-    ### Entirely trait-based I/O
-
-    This crate is entirely trait-based, which means it adds zero state at runtime. All the information needed is encoded at the type level. All functionality is delegated to (de-)serialization code.
-
-    Compared to the alternative way of per-object endianness specification via a wrapper type, traits also have the advantage that they don't limit access to the specific type at all, whereas with wrappers you need to explicitly get a reference the underlying object to use it.
-
-    ### Zero-cost abstractions
-
-    As this crate is entirely trait-based, the compiler will typically aggressively inline and optimize out all calls to this crate. The only thing remaining will be the (de-)serialization code, which is also necessary without the use of this crate. Therefore using this crate will not result in any penalty to your code, neither in speed nor memory use.
-
-    When I compared code using byte-level I/O from this crate to code using the equivalent raw `std::io` functionality in a disassembler, compiled in release mode, I only found found a difference of a few opcodes, and all function calls to this crate had been completely optimized away.
-
-    I haven't yet done any serious benchmarks, or checked the disassembly of all types and features, but these initial results look promising.
-
-    ### Extensibility: Reading & writing your own types
-
-    You can take advantage of this crate's features and the `read`/`write` methods by implementing this crate's traits for your own types. No distinction is made between user types and types for which (de-)serialization is already provided by this crate, and you will be able to use `read` and `write` for your own types just like for primitive types.
-
-    This crate includes `derive` macros for common cases, so most of the time you won't have to write the implementations yourself.
-
-    You can write (de-)serializations that differ depending on endianness, or (de-)serializations that don't differentiate and instead use the automatic endian inference of this crate to delegate endian differentiation to sub-structs.
-
-    You're not limited to `std::io::{Read, Write}` or this crate's abstractions when writing (de-)serializations, you can also use other functionality through appropriate trait bounds. For example, it's also possible to write a (de-)serialization that uses `std::io::Seek` in its code.
-
-    ### Simple migration
-
-    If you were using raw `std::io::{Read, Write}` with manual (de-)serialization code before, or a crate providing abstractions on top of `{Read, Write}`, the migration towards using this crate is extremely straightforward. Simply swap out the `std::io` traits with the endian-specific traits from this crate, and you'll have access to the direct read/write methods. You don't need to write any extra code, everything that implements `std::io::Read` or `std::io::Write` will automatically implement the endian-specific traits.
-
-    (De-)serializations for Rust's primitive types are already implemented, if it makes sense to implement them. For example, `isize` and `usize` aren't implemented, since they are inherently variable-sized and therefore can't have a portable byte representation. However, the other integral and floating point types are implemented, and if you just want to read/write some simple primitive types, using the `read`/`write` methods will Just Work™.
-
-    ## Comparison to other crates
-
-    Binary I/O and endianness conversion are common problems, and a number of crates providing solutions already exist. [See here for how they compare to this crate](https://github.com/lcdr/endio/blob/master/Comparison.md).
-
-    ## Examples
-
-    Here are some typical ways to use this crate:
-
-    ### Read data from bytes in memory, in little endian:
-
-    ```rust
-    // This will make the read calls use little endian.
-    use endio::LERead;
-
-    // Works with any object implementing std::io::Read.
-    let mut reader = &b"\x2a\x01\x2c\xf3\xfe\xcf"[..];
-
-    let a: u8   = reader.read().unwrap();     // Reads in little endian (specified by trait).
-    let b: bool = reader.read().unwrap();     // Deserialization code is automatically inferred.
-    let c: u32  = reader.read_be().unwrap();  // Reads in forced big endian.
-
-    // The results are already converted into the appropriate types and ready for use.
-    assert_eq!(a, 42);
-    assert_eq!(b, true);
-    assert_eq!(c, 754187983);
-    ```
-
-    ### Write data to a vector of bytes, in big endian:
-
-    ```rust
-    // This time we'll use big endian.
-    use endio::BEWrite;
-
-    // Vec implements std::io::Write.
-    let mut writer = vec![];
-
-    writer.write(42u8);          // Directly specifying values works fine.
-    writer.write(true);          // Everything is automatically converted to bytes.
-    writer.write_le(754187983);  // The trait endianness can be overwritten if necessary.
-
-    // Done!
-    assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
-    ```
-
-    ### Directly read a custom type:
-
-    ```rust
-    # #[cfg(feature="derive")] {
-    use endio::Deserialize;
-
-    // The derive macro takes care of the implementation code.
-    #[derive(Deserialize)]
-    struct Example {
-        a: u16,
-        b: bool,
-        c: u32,
-    }
-
-    // The macro has implemented both LE and BE, we'll choose one of them here.
-    use endio::LERead;
-    let mut reader = &b"\xba\xad\x01\xba\xad\xf0\x0d"[..];
-    let val: Example = reader.read().unwrap();
-    assert!(matches!(val, Example { a: 0xadba, b: true, c: 0x0df0adba }));
-    # }
-    ```
-
-    More examples and explanations on how this crate works are included in the documentation of the interfaces.
-    There are also examples on how to implement your own types.
-
-    ## Getting started
-
-    To conduct I/O you `use` the traits `BERead` & `BEWrite`, or `LERead` & `LEWrite`. Choose `BERead` & `BEWrite` for big endian I/O, and `LERead` & `LEWrite` for little endian I/O. This will give you the `read`/`write` methods on your structs. `read` returns values of your desired type, and `write` accepts values as a parameter. The deserialization to be used and the type to be returned are handled through type inference, so most of the time you won't even need to annotate the type explicitly.
-
-    You can read and write your own types by implementing `Serialize`/`Deserialize`. See their documentation for details.
-*/
+//! ## Simple and ergonomic reading and writing of binary data.
+//!
+//! `std::io::{Read, Write}` only allow reading and writing of raw bytes. This can be cumbersome when trying to read/write data, e.g. integers, as they have to be converted from/to bytes first.
+//! This crate allows direct reading/writing of data types, making this as easy as
+//!
+//! `let value: u8 = reader.read()?;`
+//!
+//! and
+//!
+//! `writer.write(42u8);`.
+//!
+//! ### Per-object endianness specification
+//!
+//! When working with integers consisting of multiple bytes, two kinds of byte ordering are possible, big and little endian. This crate can automatically convert integers from/to the desired endianness when they're read/written, without you having to specify the endianness for every read/write call. This works by making the endianness part of the type of the read/write implementor through different traits. In most scenarios the endianness stays the same for the entirety of the I/O, so this can save a lot of typing.
+//!
+//! You aren't bound to the specified endianness for the entirety of the I/O. If you need to work with data where the endianness changes midway through, you can explicitly override the endianness with the `_be`-/`_le` -suffixed methods.
+//!
+//! ### Entirely trait-based I/O
+//!
+//! This crate is entirely trait-based, which means it adds zero state at runtime. All the information needed is encoded at the type level. All functionality is delegated to (de-)serialization code.
+//!
+//! Compared to the alternative way of per-object endianness specification via a wrapper type, traits also have the advantage that they don't limit access to the specific type at all, whereas with wrappers you need to explicitly get a reference the underlying object to use it.
+//!
+//! ### Zero-cost abstractions
+//!
+//! As this crate is entirely trait-based, the compiler will typically aggressively inline and optimize out all calls to this crate. The only thing remaining will be the (de-)serialization code, which is also necessary without the use of this crate. Therefore using this crate will not result in any penalty to your code, neither in speed nor memory use.
+//!
+//! When I compared code using byte-level I/O from this crate to code using the equivalent raw `std::io` functionality in a disassembler, compiled in release mode, I only found found a difference of a few opcodes, and all function calls to this crate had been completely optimized away.
+//!
+//! I haven't yet done any serious benchmarks, or checked the disassembly of all types and features, but these initial results look promising.
+//!
+//! ### Extensibility: Reading & writing your own types
+//!
+//! You can take advantage of this crate's features and the `read`/`write` methods by implementing this crate's traits for your own types. No distinction is made between user types and types for which (de-)serialization is already provided by this crate, and you will be able to use `read` and `write` for your own types just like for primitive types.
+//!
+//! This crate includes `derive` macros for common cases, so most of the time you won't have to write the implementations yourself.
+//!
+//! You can write (de-)serializations that differ depending on endianness, or (de-)serializations that don't differentiate and instead use the automatic endian inference of this crate to delegate endian differentiation to sub-structs.
+//!
+//! You're not limited to `std::io::{Read, Write}` or this crate's abstractions when writing (de-)serializations, you can also use other functionality through appropriate trait bounds. For example, it's also possible to write a (de-)serialization that uses `std::io::Seek` in its code.
+//!
+//! ### Simple migration
+//!
+//! If you were using raw `std::io::{Read, Write}` with manual (de-)serialization code before, or a crate providing abstractions on top of `{Read, Write}`, the migration towards using this crate is extremely straightforward. Simply swap out the `std::io` traits with the endian-specific traits from this crate, and you'll have access to the direct read/write methods. You don't need to write any extra code, everything that implements `std::io::Read` or `std::io::Write` will automatically implement the endian-specific traits.
+//!
+//! (De-)serializations for Rust's primitive types are already implemented, if it makes sense to implement them. For example, `isize` and `usize` aren't implemented, since they are inherently variable-sized and therefore can't have a portable byte representation. However, the other integral and floating point types are implemented, and if you just want to read/write some simple primitive types, using the `read`/`write` methods will Just Work™.
+//!
+//! ## Comparison to other crates
+//!
+//! Binary I/O and endianness conversion are common problems, and a number of crates providing solutions already exist. [See here for how they compare to this crate](https://github.com/lcdr/endio/blob/master/Comparison.md).
+//!
+//! ## Examples
+//!
+//! Here are some typical ways to use this crate:
+//!
+//! ### Read data from bytes in memory, in little endian:
+//!
+//! ```rust
+//! // This will make the read calls use little endian.
+//! use endio::LERead;
+//!
+//! // Works with any object implementing std::io::Read.
+//! let mut reader = &b"\x2a\x01\x2c\xf3\xfe\xcf"[..];
+//!
+//! let a: u8   = reader.read().unwrap();     // Reads in little endian (specified by trait).
+//! let b: bool = reader.read().unwrap();     // Deserialization code is automatically inferred.
+//! let c: u32  = reader.read_be().unwrap();  // Reads in forced big endian.
+//!
+//! // The results are already converted into the appropriate types and ready for use.
+//! assert_eq!(a, 42);
+//! assert_eq!(b, true);
+//! assert_eq!(c, 754187983);
+//! ```
+//!
+//! ### Write data to a vector of bytes, in big endian:
+//!
+//! ```rust
+//! // This time we'll use big endian.
+//! use endio::BEWrite;
+//!
+//! // Vec implements std::io::Write.
+//! let mut writer = vec![];
+//!
+//! writer.write(42u8);          // Directly specifying values works fine.
+//! writer.write(true);          // Everything is automatically converted to bytes.
+//! writer.write_le(754187983);  // The trait endianness can be overwritten if necessary.
+//!
+//! // Done!
+//! assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
+//! ```
+//!
+//! ### Directly read a custom type:
+//!
+//! ```rust
+//! # #[cfg(feature="derive")] {
+//! use endio::Deserialize;
+//!
+//! // The derive macro takes care of the implementation code.
+//! #[derive(Deserialize)]
+//! struct Example {
+//!     a: u16,
+//!     b: bool,
+//!     c: u32,
+//! }
+//!
+//! // The macro has implemented both LE and BE, we'll choose one of them here.
+//! use endio::LERead;
+//! let mut reader = &b"\xba\xad\x01\xba\xad\xf0\x0d"[..];
+//! let val: Example = reader.read().unwrap();
+//! assert!(matches!(val, Example { a: 0xadba, b: true, c: 0x0df0adba }));
+//! # }
+//! ```
+//!
+//! More examples and explanations on how this crate works are included in the documentation of the interfaces.
+//! There are also examples on how to implement your own types.
+//!
+//! ## Getting started
+//!
+//! To conduct I/O you `use` the traits `BERead` & `BEWrite`, or `LERead` & `LEWrite`. Choose `BERead` & `BEWrite` for big endian I/O, and `LERead` & `LEWrite` for little endian I/O. This will give you the `read`/`write` methods on your structs. `read` returns values of your desired type, and `write` accepts values as a parameter. The deserialization to be used and the type to be returned are handled through type inference, so most of the time you won't even need to annotate the type explicitly.
+//!
+//! You can read and write your own types by implementing `Serialize`/`Deserialize`. See their documentation for details.
 
 mod deserialize;
 mod endian;

--- a/src/read.rs
+++ b/src/read.rs
@@ -3,34 +3,30 @@ use std::io::Result as Res;
 
 use crate::{BigEndian, Deserialize, Endianness, LittleEndian};
 
-/**
-    Only necessary for custom (de-)serializations.
-
-    Interface for reading data with a specified endianness. Use this interface to make deserializations automatically switch endianness without having to write the same code twice.
-
-    In theory this would be the only read trait and BE-/LERead would be aliases to the BE/LE type parameter variants, but trait aliases aren't stable yet.
-
-    ## Examples
-
-    ```
-    use endio::LERead;
-
-    let mut reader = &b"\x2a\x01\xcf\xfe\xf3\x2c"[..];
-    let a: u8 = reader.read().unwrap();
-    let b: bool = reader.read().unwrap();
-    let c: u32 = reader.read().unwrap();
-    assert_eq!(a, 42);
-    assert_eq!(b, true);
-    assert_eq!(c, 754187983);
-    ```
-*/
+/// Only necessary for custom (de-)serializations.
+///
+/// Interface for reading data with a specified endianness. Use this interface to make deserializations automatically switch endianness without having to write the same code twice.
+///
+/// In theory this would be the only read trait and BE-/LERead would be aliases to the BE/LE type parameter variants, but trait aliases aren't stable yet.
+///
+/// ## Examples
+///
+/// ```
+/// use endio::LERead;
+///
+/// let mut reader = &b"\x2a\x01\xcf\xfe\xf3\x2c"[..];
+/// let a: u8 = reader.read().unwrap();
+/// let b: bool = reader.read().unwrap();
+/// let c: u32 = reader.read().unwrap();
+/// assert_eq!(a, 42);
+/// assert_eq!(b, true);
+/// assert_eq!(c, 754187983);
+/// ```
 pub trait ERead<E: Endianness>: Sized {
     // todo[supertrait item shadowing]: make Read a supertrait of this
-    /**
-        Reads a `Deserialize` from the reader, in the reader's endianness.
-
-        What's actually read is up to the implementation of the `Deserialize`.
-    */
+    /// Reads a `Deserialize` from the reader, in the reader's endianness.
+    ///
+    /// What's actually read is up to the implementation of the `Deserialize`.
     fn read<D: Deserialize<E, Self>>(&mut self) -> Res<D> {
         D::deserialize(self)
     }
@@ -45,14 +41,11 @@ pub trait ERead<E: Endianness>: Sized {
 }
 
 // todo[trait aliases]: make these aliases of ERead
-
-/**
-    Use this to `read` in **big** endian.
-
-    Wrapper for `ERead<BigEndian>`.
-
-    This exists solely to make `use` notation work. See `ERead` for documentation.
-*/
+/// Use this to `read` in **big** endian.
+///
+/// Wrapper for `ERead<BigEndian>`.
+///
+/// This exists solely to make `use` notation work. See `ERead` for documentation.
 pub trait BERead: Sized {
     fn read<D: Deserialize<BigEndian, Self>>(&mut self) -> Res<D> {
         D::deserialize(self)
@@ -65,13 +58,11 @@ pub trait BERead: Sized {
     }
 }
 
-/**
-    Use this to `read` in **little** endian.
-
-    Wrapper for `ERead<LittleEndian>`.
-
-    This exists solely to make `use` notation work. See `ERead` for documentation.
-*/
+/// Use this to `read` in **little** endian.
+///
+/// Wrapper for `ERead<LittleEndian>`.
+///
+/// This exists solely to make `use` notation work. See `ERead` for documentation.
 pub trait LERead: Sized {
     fn read<D: Deserialize<LittleEndian, Self>>(&mut self) -> Res<D> {
         D::deserialize(self)

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -4,288 +4,286 @@ use std::net::Ipv4Addr;
 
 use crate::{BEWrite, BigEndian, EWrite, Endianness, LEWrite, LittleEndian};
 
-/**
-    Implement this for your types to be able to `write` them.
-
-    ## Derive macro for common serializations
-
-    A common case is the following: You want to make your struct serializable. Your struct's fields are all serializable themselves. You want to simply serialize everything in order, and then construct a struct instance from that.
-
-    If that's all you want, simply `#[derive(Serialize)]` and you're good to go.
-
-    ## Examples
-
-    ### Serialize a struct:
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    struct Example {
-        a: u16,
-        b: bool,
-        c: u32,
-    }
-    # {
-    use endio::LEWrite;
-    let mut writer = vec![];
-    writer.write(&Example { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
-    assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # {
-    # use endio::BEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example { a: 0xbaad, b: true, c: 0xbaadf00d }).unwrap();
-    # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # }
-    ```
-
-    This also works with tuple structs:
-
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    struct Example(u16, bool, u32);
-    # {
-    # use endio::LEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example(0xadba, true, 0x0df0adba)).unwrap();
-    # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # {
-    # use endio::BEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example(0xbaad, true, 0xbaadf00d)).unwrap();
-    # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # }
-    ```
-
-    and unit structs:
-
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    struct Example;
-
-    # {
-    # use endio::LEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example).unwrap();
-    # assert_eq!(writer, b"");
-    # }
-    # {
-    # use endio::BEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example).unwrap();
-    # assert_eq!(writer, b"");
-    # }
-    # }
-    ```
-
-    ### Serialize an enum:
-
-    The derive macro also works with enums, however you will have to explicitly specify the type of the discriminant by adding a repr attribute with an int type argument to the enum.
-
-    The derive macro works even without explicitly specified discriminant values and with variants carrying data. Nightly Rust also supports the combination of both under [`#![feature(arbitrary_enum_discriminant)]`](https://github.com/rust-lang/rust/issues/60553).
-
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    #[repr(u16)]
-    enum Example {
-        A,
-        B,
-        C = 42,
-        D,
-    }
-    # {
-    use endio::LEWrite;
-    let mut writer = vec![];
-    writer.write(&Example::A).unwrap();
-    assert_eq!(writer, b"\x00\x00");
-    # writer.write(&Example::B).unwrap();
-    # writer.write(&Example::C).unwrap();
-    # writer.write(&Example::D).unwrap();
-    # assert_eq!(writer, b"\x00\x00\x01\x00\x2a\x00\x2b\x00");
-    # }
-    # {
-    # use endio::BEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example::A).unwrap();
-    # assert_eq!(writer, b"\x00\x00");
-    # writer.write(&Example::B).unwrap();
-    # writer.write(&Example::C).unwrap();
-    # writer.write(&Example::D).unwrap();
-    # assert_eq!(writer, b"\x00\x00\x00\x01\x00\x2a\x00\x2b");
-    # }
-    # }
-    ```
-
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    #[repr(u16)]
-    enum Example {
-        A,
-        B(u8),
-        C { a: u16, b: bool, c: u32 },
-        D(u32),
-    }
-    # {
-    use endio::LEWrite;
-    let mut writer = vec![];
-    writer.write(&Example::C { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
-    assert_eq!(writer, b"\x02\x00\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # {
-    # use endio::BEWrite;
-    # let mut writer = vec![];
-    # writer.write(&Example::C { a: 0xbaad, b: true, c: 0xbaadf00d }).unwrap();
-    # assert_eq!(writer, b"\x00\x02\xba\xad\x01\xba\xad\xf0\x0d");
-    # }
-    # }
-    ```
-
-    ### Padding
-
-    Sometimes you'll have to work with formats containing padding bytes of useless data, or you know that the recipient will ignore some parts. This derive macro provides some attributes to support these cases:
-
-    - Add the `#[padding=n]` attribute to fields to specify `n` bytes of padding before the field.
-    - Add the `#[pre_disc_padding=n]` attribute on an enum to specify `n` bytes of padding before the discriminant.
-    - Add the `#[post_disc_padding=n]` attribute on an enum to specify `n` bytes of padding after the discriminant.
-    - Add the `#[trailing_padding=n]` attribute on a struct or enum to specify `n` bytes of padding after the struct/enum.
-
-    The derive macro will then automatically write zeros for these bytes.
-
-    ```
-    # #[cfg(feature="derive")] {
-    # use endio::Serialize;
-    #[derive(Serialize)]
-    #[pre_disc_padding=1]
-    #[repr(u16)]
-    #[post_disc_padding=3]
-    #[trailing_padding=1]
-    enum Example {
-        A {
-            a: u16,
-            #[padding=1]
-            b: bool,
-            #[padding=1]
-            c: u32,
-        },
-    }
-    use endio::LEWrite;
-    let mut writer = vec![];
-    writer.write(&Example::A { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
-    assert_eq!(writer, b"\x00\x00\x00\x00\x00\x00\xba\xad\x00\x01\x00\xba\xad\xf0\x0d\x00");
-    # }
-    ```
-
-    ## Custom serializations
-
-    If your serialization is complex or has special cases, you'll need to implement `Serialize` manually.
-
-    ### Examples
-
-    ### Serialize a struct:
-
-    Note how the trait bound for `W` is `EWrite<E>`, as we want to use the functionality of this crate to delegate serialization to the struct's fields.
-
-    Note: As you can see below, you may need to write `where` clauses when delegating functionality to other `write` operations. There are two reasons for this:
-
-    - Rust currently can't recognize sealed traits. Even though there are only two endiannesses, and the primitive types are implemented for them, the compiler can't recognize that. If/When the compiler gets smarter about sealed traits this will be resolved. Alternatively, once Rust gets support for specialization, I will be able to add a dummy blanket `impl` to primitives which will work around this issue.
-
-    - The underlying `W` type needs to implement `std::io::Write` to be able to write primitive types. You can work around this by explicitly specifying `Write` as trait bound, but since both `Write` and `EWrite` have a `write` method, Rust will force you to use UFCS syntax to disambiguate between them. This makes using `write` less ergonomic, and I personally think that `where` clauses are the better alternative here, since they avoid this issue.
-
-        Ideally I'd like to make `std::io::Write` a supertrait of `EWrite`, since the serialization will normally depend on `Write` anyway. Unfortunately, supertraits' methods automatically get brought into scope, so this would mean that you would be forced to use UFCS every time, without being able to work around them with `where` clauses. ([Rust issue #17151](https://github.com/rust-lang/rust/issues/17151)).
-    ```
-    struct Example {
-        a: u8,
-        b: bool,
-        c: u32,
-    }
-    # {
-    use std::io::Result;
-    use endio::{Endianness, EWrite, Serialize};
-
-    impl<E: Endianness, W: EWrite<E>> Serialize<E, W> for &Example
-        where u8  : Serialize<E, W>,
-              bool: Serialize<E, W>,
-              u32 : Serialize<E, W> {
-        fn serialize(self, writer: &mut W) -> Result<()> {
-            writer.write(self.a)?;
-            writer.write(self.b)?;
-            writer.write(self.c)
-        }
-    }
-    # }
-    // will then allow you to directly write:
-    # {
-    use endio::LEWrite;
-    let mut writer = vec![];
-    let e = Example { a: 42, b: true, c: 754187983 };
-    writer.write(&e);
-    assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
-    # }
-    # {
-    #     use endio::BEWrite;
-    #     let mut writer = vec![];
-    #     let e = Example { a: 42, b: true, c: 754187983 };
-    #     writer.write(&e);
-    #     assert_eq!(writer, b"\x2a\x01\x2c\xf3\xfe\xcf");
-    # }
-    ```
-
-    ### Serialize a primitive / something where you need to use the bare `std::io::Write` functionality:
-
-    Note how the trait bound for `W` is `Write`.
-    ```
-    use std::io::{Result, Write};
-    use endio::{Endianness, EWrite, Serialize};
-
-    struct new_u8(u8);
-
-    impl<E: Endianness, W: Write> Serialize<E, W> for &new_u8 {
-        fn serialize(self, writer: &mut W) -> Result<()> {
-            let mut buf = [0; 1];
-            buf[0] = self.0;
-            writer.write_all(&buf);
-            Ok(())
-        }
-    }
-    ```
-
-    ### Serialize with endian-specific code:
-
-    Note how instead of using a trait bound on Endianness, we implement Serialize twice, once for `BigEndian` and once for `LittleEndian`.
-    ```
-    use std::io::{Result, Write};
-    use std::mem::size_of;
-    use endio::{BigEndian, Serialize, LittleEndian};
-
-    struct new_u16(u16);
-
-    impl<W: Write> Serialize<BigEndian, W> for new_u16 {
-        fn serialize(self, writer: &mut W) -> Result<()> {
-            let mut buf = [0; size_of::<u16>()];
-            writer.write_all(&self.0.to_be_bytes())?;
-            Ok(())
-        }
-    }
-
-    impl<W: Write> Serialize<LittleEndian, W> for new_u16 {
-        fn serialize(self, writer: &mut W) -> Result<()> {
-            writer.write_all(&self.0.to_le_bytes())?;
-            Ok(())
-        }
-    }
-    ```
-*/
+/// Implement this for your types to be able to `write` them.
+///
+/// ## Derive macro for common serializations
+///
+/// A common case is the following: You want to make your struct serializable. Your struct's fields are all serializable themselves. You want to simply serialize everything in order, and then construct a struct instance from that.
+///
+/// If that's all you want, simply `#[derive(Serialize)]` and you're good to go.
+///
+/// ## Examples
+///
+/// ### Serialize a struct:
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// struct Example {
+///     a: u16,
+///     b: bool,
+///     c: u32,
+/// }
+/// # {
+/// use endio::LEWrite;
+/// let mut writer = vec![];
+/// writer.write(&Example { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
+/// assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # {
+/// # use endio::BEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example { a: 0xbaad, b: true, c: 0xbaadf00d }).unwrap();
+/// # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # }
+/// ```
+///
+/// This also works with tuple structs:
+///
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// struct Example(u16, bool, u32);
+/// # {
+/// # use endio::LEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example(0xadba, true, 0x0df0adba)).unwrap();
+/// # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # {
+/// # use endio::BEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example(0xbaad, true, 0xbaadf00d)).unwrap();
+/// # assert_eq!(writer, b"\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # }
+/// ```
+///
+/// and unit structs:
+///
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// struct Example;
+///
+/// # {
+/// # use endio::LEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example).unwrap();
+/// # assert_eq!(writer, b"");
+/// # }
+/// # {
+/// # use endio::BEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example).unwrap();
+/// # assert_eq!(writer, b"");
+/// # }
+/// # }
+/// ```
+///
+/// ### Serialize an enum:
+///
+/// The derive macro also works with enums, however you will have to explicitly specify the type of the discriminant by adding a repr attribute with an int type argument to the enum.
+///
+/// The derive macro works even without explicitly specified discriminant values and with variants carrying data. Nightly Rust also supports the combination of both under [`#![feature(arbitrary_enum_discriminant)]`](https://github.com/rust-lang/rust/issues/60553).
+///
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// #[repr(u16)]
+/// enum Example {
+///     A,
+///     B,
+///     C = 42,
+///     D,
+/// }
+/// # {
+/// use endio::LEWrite;
+/// let mut writer = vec![];
+/// writer.write(&Example::A).unwrap();
+/// assert_eq!(writer, b"\x00\x00");
+/// # writer.write(&Example::B).unwrap();
+/// # writer.write(&Example::C).unwrap();
+/// # writer.write(&Example::D).unwrap();
+/// # assert_eq!(writer, b"\x00\x00\x01\x00\x2a\x00\x2b\x00");
+/// # }
+/// # {
+/// # use endio::BEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example::A).unwrap();
+/// # assert_eq!(writer, b"\x00\x00");
+/// # writer.write(&Example::B).unwrap();
+/// # writer.write(&Example::C).unwrap();
+/// # writer.write(&Example::D).unwrap();
+/// # assert_eq!(writer, b"\x00\x00\x00\x01\x00\x2a\x00\x2b");
+/// # }
+/// # }
+/// ```
+///
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// #[repr(u16)]
+/// enum Example {
+///     A,
+///     B(u8),
+///     C { a: u16, b: bool, c: u32 },
+///     D(u32),
+/// }
+/// # {
+/// use endio::LEWrite;
+/// let mut writer = vec![];
+/// writer.write(&Example::C { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
+/// assert_eq!(writer, b"\x02\x00\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # {
+/// # use endio::BEWrite;
+/// # let mut writer = vec![];
+/// # writer.write(&Example::C { a: 0xbaad, b: true, c: 0xbaadf00d }).unwrap();
+/// # assert_eq!(writer, b"\x00\x02\xba\xad\x01\xba\xad\xf0\x0d");
+/// # }
+/// # }
+/// ```
+///
+/// ### Padding
+///
+/// Sometimes you'll have to work with formats containing padding bytes of useless data, or you know that the recipient will ignore some parts. This derive macro provides some attributes to support these cases:
+///
+/// - Add the `#[padding=n]` attribute to fields to specify `n` bytes of padding before the field.
+/// - Add the `#[pre_disc_padding=n]` attribute on an enum to specify `n` bytes of padding before the discriminant.
+/// - Add the `#[post_disc_padding=n]` attribute on an enum to specify `n` bytes of padding after the discriminant.
+/// - Add the `#[trailing_padding=n]` attribute on a struct or enum to specify `n` bytes of padding after the struct/enum.
+///
+/// The derive macro will then automatically write zeros for these bytes.
+///
+/// ```
+/// # #[cfg(feature="derive")] {
+/// # use endio::Serialize;
+/// #[derive(Serialize)]
+/// #[pre_disc_padding=1]
+/// #[repr(u16)]
+/// #[post_disc_padding=3]
+/// #[trailing_padding=1]
+/// enum Example {
+///     A {
+///         a: u16,
+///         #[padding=1]
+///         b: bool,
+///         #[padding=1]
+///         c: u32,
+///     },
+/// }
+/// use endio::LEWrite;
+/// let mut writer = vec![];
+/// writer.write(&Example::A { a: 0xadba, b: true, c: 0x0df0adba }).unwrap();
+/// assert_eq!(writer, b"\x00\x00\x00\x00\x00\x00\xba\xad\x00\x01\x00\xba\xad\xf0\x0d\x00");
+/// # }
+/// ```
+///
+/// ## Custom serializations
+///
+/// If your serialization is complex or has special cases, you'll need to implement `Serialize` manually.
+///
+/// ### Examples
+///
+/// ### Serialize a struct:
+///
+/// Note how the trait bound for `W` is `EWrite<E>`, as we want to use the functionality of this crate to delegate serialization to the struct's fields.
+///
+/// Note: As you can see below, you may need to write `where` clauses when delegating functionality to other `write` operations. There are two reasons for this:
+///
+/// - Rust currently can't recognize sealed traits. Even though there are only two endiannesses, and the primitive types are implemented for them, the compiler can't recognize that. If/When the compiler gets smarter about sealed traits this will be resolved. Alternatively, once Rust gets support for specialization, I will be able to add a dummy blanket `impl` to primitives which will work around this issue.
+///
+/// - The underlying `W` type needs to implement `std::io::Write` to be able to write primitive types. You can work around this by explicitly specifying `Write` as trait bound, but since both `Write` and `EWrite` have a `write` method, Rust will force you to use UFCS syntax to disambiguate between them. This makes using `write` less ergonomic, and I personally think that `where` clauses are the better alternative here, since they avoid this issue.
+///
+///     Ideally I'd like to make `std::io::Write` a supertrait of `EWrite`, since the serialization will normally depend on `Write` anyway. Unfortunately, supertraits' methods automatically get brought into scope, so this would mean that you would be forced to use UFCS every time, without being able to work around them with `where` clauses. ([Rust issue #17151](https://github.com/rust-lang/rust/issues/17151)).
+/// ```
+/// struct Example {
+///     a: u8,
+///     b: bool,
+///     c: u32,
+/// }
+/// # {
+/// use std::io::Result;
+/// use endio::{Endianness, EWrite, Serialize};
+///
+/// impl<E: Endianness, W: EWrite<E>> Serialize<E, W> for &Example
+///     where u8  : Serialize<E, W>,
+///           bool: Serialize<E, W>,
+///           u32 : Serialize<E, W> {
+///     fn serialize(self, writer: &mut W) -> Result<()> {
+///         writer.write(self.a)?;
+///         writer.write(self.b)?;
+///         writer.write(self.c)
+///     }
+/// }
+/// # }
+/// // will then allow you to directly write:
+/// # {
+/// use endio::LEWrite;
+/// let mut writer = vec![];
+/// let e = Example { a: 42, b: true, c: 754187983 };
+/// writer.write(&e);
+/// assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
+/// # }
+/// # {
+/// #     use endio::BEWrite;
+/// #     let mut writer = vec![];
+/// #     let e = Example { a: 42, b: true, c: 754187983 };
+/// #     writer.write(&e);
+/// #     assert_eq!(writer, b"\x2a\x01\x2c\xf3\xfe\xcf");
+/// # }
+/// ```
+///
+/// ### Serialize a primitive / something where you need to use the bare `std::io::Write` functionality:
+///
+/// Note how the trait bound for `W` is `Write`.
+/// ```
+/// use std::io::{Result, Write};
+/// use endio::{Endianness, EWrite, Serialize};
+///
+/// struct new_u8(u8);
+///
+/// impl<E: Endianness, W: Write> Serialize<E, W> for &new_u8 {
+///     fn serialize(self, writer: &mut W) -> Result<()> {
+///         let mut buf = [0; 1];
+///         buf[0] = self.0;
+///         writer.write_all(&buf);
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// ### Serialize with endian-specific code:
+///
+/// Note how instead of using a trait bound on Endianness, we implement Serialize twice, once for `BigEndian` and once for `LittleEndian`.
+/// ```
+/// use std::io::{Result, Write};
+/// use std::mem::size_of;
+/// use endio::{BigEndian, Serialize, LittleEndian};
+///
+/// struct new_u16(u16);
+///
+/// impl<W: Write> Serialize<BigEndian, W> for new_u16 {
+///     fn serialize(self, writer: &mut W) -> Result<()> {
+///         let mut buf = [0; size_of::<u16>()];
+///         writer.write_all(&self.0.to_be_bytes())?;
+///         Ok(())
+///     }
+/// }
+///
+/// impl<W: Write> Serialize<LittleEndian, W> for new_u16 {
+///     fn serialize(self, writer: &mut W) -> Result<()> {
+///         writer.write_all(&self.0.to_le_bytes())?;
+///         Ok(())
+///     }
+/// }
+/// ```
 pub trait Serialize<E: Endianness, W> {
     /// Serializes the type by writing to the writer.
     fn serialize(self, writer: &mut W) -> Res<()>;

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,33 +3,29 @@ use std::io::Write;
 
 use crate::{BigEndian, Endianness, LittleEndian, Serialize};
 
-/**
-    Only necessary for custom (de-)serializations.
-
-    Interface for writing data with a specified endianness. Use this interface to make serializations automatically switch endianness without having to write the same code twice.
-
-    In theory this would be the only write trait and BE-/LEWrite would be aliases to the BE/LE type parameter variants, but trait aliases aren't stable yet.
-
-    ## Examples
-
-    ```
-    use endio::LEWrite;
-
-    let mut writer = vec![];
-    writer.write(42u8);
-    writer.write(true);
-    writer.write(754187983u32);
-
-    assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
-    ```
-*/
+///  Only necessary for custom (de-)serializations.
+///
+/// Interface for writing data with a specified endianness. Use this interface to make serializations automatically switch endianness without having to write the same code twice.
+///
+/// In theory this would be the only write trait and BE-/LEWrite would be aliases to the BE/LE type parameter variants, but trait aliases aren't stable yet.
+///
+/// ## Examples
+///
+/// ```
+/// use endio::LEWrite;
+///
+/// let mut writer = vec![];
+/// writer.write(42u8);
+/// writer.write(true);
+/// writer.write(754187983u32);
+///
+/// assert_eq!(writer, b"\x2a\x01\xcf\xfe\xf3\x2c");
+/// ```
 pub trait EWrite<E: Endianness>: Sized {
     // todo[supertrait item shadowing]: make Write a supertrait of this
-    /**
-        Writes a `Serialize` to the writer, in the writer's endianness.
-
-        What's actually written is up to the implementation of the `Serialize`.
-    */
+    /// Writes a `Serialize` to the writer, in the writer's endianness.
+    ///
+    /// What's actually written is up to the implementation of the `Serialize`.
     fn write<S: Serialize<E, Self>>(&mut self, ser: S) -> Res<()> {
         ser.serialize(self)
     }
@@ -44,14 +40,11 @@ pub trait EWrite<E: Endianness>: Sized {
 }
 
 // todo[trait aliases]: make these aliases of EWrite
-
-/**
-    Use this to `write` in **big** endian.
-
-    Wrapper for `EWrite<BigEndian>`.
-
-    This exists solely to make `use` notation work. See `EWrite` for documentation.
-*/
+/// Use this to `write` in **big** endian.
+///
+/// Wrapper for `EWrite<BigEndian>`.
+///
+/// This exists solely to make `use` notation work. See `EWrite` for documentation.
 pub trait BEWrite: Sized {
     fn write<S: Serialize<BigEndian, Self>>(&mut self, ser: S) -> Res<()> {
         ser.serialize(self)
@@ -64,13 +57,11 @@ pub trait BEWrite: Sized {
     }
 }
 
-/**
-    Use this to `write` in **little** endian.
-
-    Wrapper for `EWrite<LittleEndian>`.
-
-    This exists solely to make `use` notation work. See `EWrite` for documentation.
-*/
+/// Use this to `write` in **little** endian.
+///
+/// Wrapper for `EWrite<LittleEndian>`.
+///
+/// This exists solely to make `use` notation work. See `EWrite` for documentation.
 pub trait LEWrite: Sized {
     fn write<S: Serialize<LittleEndian, Self>>(&mut self, ser: S) -> Res<()> {
         ser.serialize(self)


### PR DESCRIPTION
Change the documentation comments to use the standard Rust format